### PR TITLE
Make Plugin Settings optional

### DIFF
--- a/includes/class-sp-api.php
+++ b/includes/class-sp-api.php
@@ -195,7 +195,7 @@ class SortablePosts_API {
 
 		// Insert the new order
 		$new_order = $wpdb->query(
-			"UPDATE wp_posts SET menu_order = ( @i:= @i+1 )
+			"UPDATE {$wpdb->posts} SET menu_order = ( @i:= @i+1 )
 			WHERE ID IN ( $this->order ) ORDER BY FIELD( ID, $this->order );"
 		, ARRAY_A );
 

--- a/includes/class-sp-settings.php
+++ b/includes/class-sp-settings.php
@@ -32,7 +32,9 @@ class SortablePosts_Settings {
 	 */
 	public function register_menu()
 	{
-		add_options_page( __( 'Sortable Posts For WordPress', SortablePosts::$textdomain ), __( 'Sortable Posts', SortablePosts::$textdomain ), 'administrator', 'sortable_posts_settings', array( $this, 'settings_html' ) );
+		if ( apply_filters( 'sortable_posts_settings', true ) ) {
+			add_options_page( __( 'Sortable Posts For WordPress', SortablePosts::$textdomain ), __( 'Sortable Posts', SortablePosts::$textdomain ), 'administrator', 'sortable_posts_settings', array( $this, 'settings_html' ) );
+		}
 	}
 
 	/**

--- a/includes/class-sp-taxonomies.php
+++ b/includes/class-sp-taxonomies.php
@@ -101,8 +101,12 @@ class SortablePosts_Taxonomies {
 			return $clauses;
 		}
 
+		// taxonomies might come as associative array.
+		// make sure $taxonomy_values[0] won't trigger a php warning
+		$taxonomy_values = array_values( $taxonomies );
+
 		// Accept only single taxonomy queries & only if taxonomy is sortable
-		if ( ! in_array( $taxonomies[0], $this->sortable_taxes ) ) {
+		if ( ! in_array( $taxonomy_values[0], $this->sortable_taxes ) ) {
 			return $clauses;
 		}
 

--- a/sortable-posts.php
+++ b/sortable-posts.php
@@ -70,7 +70,9 @@ if( ! class_exists( 'SortablePosts' ) ) {
 		 */
 		public function includes()
 		{
-			require_once( 'includes/class-sp-settings.php' );
+			if ( is_admin() ) {
+				require_once( 'includes/class-sp-settings.php' );
+			}
 			require_once( 'includes/class-sp-api.php' );
 			require_once( 'includes/class-sp-taxonomies.php' );
 		}


### PR DESCRIPTION
- Load `includes/class-sp-settings.php` only if `is_admin()` (reduce frontend overhead)
- introduce new filter `sortable_posts_settings` (allow developers to turn off plugin settings)