### PR TITLE
Order by Post type inside a taxonomy term

### DIFF
--- a/assets/js/sortable-posts.js
+++ b/assets/js/sortable-posts.js
@@ -3,7 +3,6 @@ jQuery(document).ready(function($)
 	var list 		= $('body.sortable-posts .wp-list-table #the-list'),
 		rows		= list.find('tr'),
 		statusBox	= $( '#sortable-posts-status' ),
-		statusHead	= statusBox.find( '#sortable-posts-status-head' ),
 		statusMsg	= statusBox.find( '#sortable-posts-status-message' );
 
 	// Create helper so row columns maintain their width.
@@ -42,6 +41,9 @@ jQuery(document).ready(function($)
 				order: order,
 				start: WP_API_Settings.start,
 				object_type: WP_API_Settings.obj_type,
+				post_type: jQuery('.post_type_page').val(),
+				taxonomy: WP_API_Settings.taxonomy,
+				taxonomy_term: WP_API_Settings.taxonomy_term
 			}
 		}).done( function( response ) {
 

--- a/includes/class-sp-api.php
+++ b/includes/class-sp-api.php
@@ -257,7 +257,7 @@ class SortablePosts_API {
 			$position = abs( $position + 1 );
 			
 			// Update the term_order
-			update_post_meta( $term_id, '_sortable_posts_order_' . $this->post_type . '-' . $this->taxonomy . '-' . $this->taxonomy_term, $position );
+			update_post_meta( $term_id, '_sortable_posts_order_' . $this->taxonomy . '_' . $this->taxonomy_term, $position );
 		  }
 		  return;
 		}

--- a/includes/class-sp-api.php
+++ b/includes/class-sp-api.php
@@ -38,6 +38,30 @@ class SortablePosts_API {
 	 * @var string
 	 */
 	public $obj_type = '';
+	
+	/**
+	 * Stores the post type
+	 * 
+	 * @since  1.0
+	 * @var string
+	 */
+	public $post_type = '';
+	
+	/**
+	 * Stores the taxonomy
+	 * 
+	 * @since  1.0
+	 * @var string
+	 */
+	public $taxonomy = '';
+	
+	/**
+	 * Stores the taxonomy term
+	 * 
+	 * @since  1.0
+	 * @var string
+	 */
+	public $taxonomy_term = '';
 
 	/**
 	 * Registers the REST API endpoints
@@ -148,6 +172,19 @@ class SortablePosts_API {
 
 		// Set the object types
 		$this->obj_type = sanitize_key( $request->get_param( 'object_type' ) );
+		
+		// Set the post types
+		$this->post_type = sanitize_key( $request->get_param( 'post_type' ) );
+		
+		// Set the taxonomy
+		if( !empty(sanitize_key( $request->get_param( 'taxonomy' ) )) ) {
+		    $this->taxonomy = sanitize_key( $request->get_param( 'taxonomy' ) );
+		}
+		
+		// Set the object types
+		if( !empty(sanitize_key( $request->get_param( 'taxonomy' ) )) ) {
+		    $this->taxonomy_term = sanitize_key( $request->get_param( 'taxonomy_term' ) );
+		}
 	}
 
 	/**
@@ -185,21 +222,45 @@ class SortablePosts_API {
 	 */
 	protected function update_post_sort_order()
 	{
-		global $wpdb;
+		// Check if the combination of post type and taxonomy	
+		$inside_tax = false;
+		if( !empty($this->taxonomy) && !empty($this->taxonomy_term) ) {
+		  $filter_inside_posts = apply_filters('sortable_post_inside_tax', array());
+		  if( is_array( $filter_inside_posts ) ){
+		    foreach ( $filter_inside_posts as $combo ) {
+			if($combo['post_type'] === $this->post_type && $combo['taxonomy'] === $this->taxonomy){
+			  $inside_tax = true;
+			  break;
+			}
+		    }
+		  }
+		}
+		if ( ! $inside_tax ) {
+		  global $wpdb;
 
-		// Select items based on the starting point
-		$wpdb->query( "SELECT @i:= $this->start-1" );
-		
-		// Order needs to be a comma separated string
-		$this->order = esc_sql( implode( ', ', $this->order ) );
+		  // Select items based on the starting point
+		  $wpdb->query( "SELECT @i:= $this->start-1" );
 
-		// Insert the new order
-		$new_order = $wpdb->query(
-			"UPDATE {$wpdb->posts} SET menu_order = ( @i:= @i+1 )
-			WHERE ID IN ( $this->order ) ORDER BY FIELD( ID, $this->order );"
-		, ARRAY_A );
+		  // Order needs to be a comma separated string
+		  $this->order = esc_sql( implode( ', ', $this->order ) );
 
-		return $new_order;
+		  // Insert the new order
+		  $new_order = $wpdb->query(
+			  "UPDATE {$wpdb->posts} SET menu_order = ( @i:= @i+1 )
+			  WHERE ID IN ( $this->order ) ORDER BY FIELD( ID, $this->order );"
+		  , ARRAY_A );
+		  return $new_order;
+		} else {
+		  foreach( (array) $this->order as $term_id ) {
+			// Get the position in the array
+			$position = array_search( $term_id, $this->order );
+			$position = abs( $position + 1 );
+			
+			// Update the term_order
+			update_post_meta( $term_id, '_sortable_posts_order_' . $this->post_type . '-' . $this->taxonomy . '-' . $this->taxonomy_term, $position );
+		  }
+		  return;
+		}
 	}
 
 	/**

--- a/includes/class-sp-taxonomies.php
+++ b/includes/class-sp-taxonomies.php
@@ -96,9 +96,11 @@ class SortablePosts_Taxonomies {
 	{
 		if( is_admin() ) {
                     global $wpdb;
-                    $screen = get_current_screen();
-                    if( $screen->base === 'edit-tags' || $screen->base === 'post' || $screen->base === 'edit' ) {
-                        return $clauses;
+                    if(function_exists('get_current_screen')) {
+                        $screen = get_current_screen();
+                        if( $screen->base === 'edit-tags' || $screen->base === 'post' || $screen->base === 'edit' ) {
+                            return $clauses;
+                        }
                     }
                     // Need to rework this. Allows users to override orderby param
                     if ( isset( $args['orderby'] ) && $args['orderby'] !== 'name' ){

--- a/includes/class-sp-taxonomies.php
+++ b/includes/class-sp-taxonomies.php
@@ -97,10 +97,9 @@ class SortablePosts_Taxonomies {
 		if( is_admin() ) {
                     global $wpdb;
                     $screen = get_current_screen();
-                    if( $screen->base === 'edit-tags' ) {
+                    if( $screen->base === 'edit-tags' || $screen->base === 'post' || $screen->base === 'edit' ) {
                         return $clauses;
                     }
-                
                     // Need to rework this. Allows users to override orderby param
                     if ( isset( $args['orderby'] ) && $args['orderby'] !== 'name' ){
                             return $clauses;

--- a/includes/class-sp-taxonomies.php
+++ b/includes/class-sp-taxonomies.php
@@ -94,39 +94,45 @@ class SortablePosts_Taxonomies {
 	 */
 	public function orderby_sortable_taxonomies( $clauses, $taxonomies, $args )
 	{
-		global $wpdb;
+		if( is_admin() ) {
+                    global $wpdb;
+                    $screen = get_current_screen();
+                    if( $screen->base === 'edit-tags' ) {
+                        return $clauses;
+                    }
+                
+                    // Need to rework this. Allows users to override orderby param
+                    if ( isset( $args['orderby'] ) && $args['orderby'] !== 'name' ){
+                            return $clauses;
+                    }
 
-		// Need to rework this. Allows users to override orderby param
-		if ( isset( $args['orderby'] ) && $args['orderby'] !== 'name' ){
-			return $clauses;
-		}
+                    // taxonomies might come as associative array.
+                    // make sure $taxonomy_values[0] won't trigger a php warning
+                    $taxonomy_values = array_values( $taxonomies );
 
-		// taxonomies might come as associative array.
-		// make sure $taxonomy_values[0] won't trigger a php warning
-		$taxonomy_values = array_values( $taxonomies );
+                    // Accept only single taxonomy queries & only if taxonomy is sortable
+                    if ( ! in_array( $taxonomy_values[0], $this->sortable_taxes ) ) {
+                            return $clauses;
+                    }
 
-		// Accept only single taxonomy queries & only if taxonomy is sortable
-		if ( ! in_array( $taxonomy_values[0], $this->sortable_taxes ) ) {
-			return $clauses;
-		}
+                    // Join termmeta to terms tables
+                    $clauses['join'] .= " INNER JOIN {$wpdb->termmeta} tm ON (t.term_id = tm.term_id AND tm.meta_key = 'term_order')";
 
-		// Join termmeta to terms tables
-		$clauses['join'] .= " INNER JOIN {$wpdb->termmeta} tm ON (t.term_id = tm.term_id AND tm.meta_key = 'term_order')";
+                    // Set order to default to ascending
+                    $order = strtoupper( $args['order'] );
+                    if ( ! in_array( $order, array('ASC', 'DESC') ) ) {
+                            $order = 'ASC';
+                    }
+                    $orderby = "ORDER BY ABS(tm.meta_value) {$order}";
 
-		// Set order to default to ascending
-		$order = strtoupper( $args['order'] );
-		if ( ! in_array( $order, array('ASC', 'DESC') ) ) {
-			$order = 'ASC';
-		}
-		$orderby = "ORDER BY ABS(tm.meta_value) {$order}";
-
-		if ( ! empty( $clauses['orderby'] ) ) {
-			// insert custom column in front of current column
-			$clauses['orderby'] = str_replace( 'ORDER BY', "{$orderby},", $clauses['orderby'] );
-		} else {
-			// sort by custom sort column and name
-			$clauses['orderby'] = "{$orderby}, name";
-		}
+                    if ( ! empty( $clauses['orderby'] ) ) {
+                            // insert custom column in front of current column
+                            $clauses['orderby'] = str_replace( 'ORDER BY', "{$orderby},", $clauses['orderby'] );
+                    } else {
+                            // sort by custom sort column and name
+                            $clauses['orderby'] = "{$orderby}, name";
+                    }
+                }
 
 		return $clauses;
 	}

--- a/sortable-posts.php
+++ b/sortable-posts.php
@@ -141,7 +141,7 @@ if( ! class_exists( 'SortablePosts' ) ) {
 		 */
 		function register_scripts()
 		{
-			global $post, $wp_query;
+			global $wp_query;
 
 			// Set the starting point for the menu_order.
 			if( isset( $wp_query->query_vars['paged'] ) ) {
@@ -159,6 +159,8 @@ if( ! class_exists( 'SortablePosts' ) ) {
 				'nonce'		=> wp_create_nonce( 'wp_rest' ),
 				'start'		=> $start,
 				'obj_type'	=> $obj_type->base,
+				'taxonomy'	=> (isset($wp_query->query_vars['taxonomy']) ? $wp_query->query_vars['taxonomy'] : ''),
+				'taxonomy_term'	=> (isset($wp_query->query_vars['term']) ? $wp_query->query_vars['term'] : ''),
 			);
 
 			// Load scripts
@@ -225,10 +227,20 @@ if( ! class_exists( 'SortablePosts' ) ) {
 		 */
 		public static function manage_custom_column( $column )
 		{
-			global $post;
+			global $post, $wp_query;
 
 			if( $column == 'sortable-posts-order' ){
-				echo '<strong class="sortable-posts-order-position">' . $post->menu_order . '</strong>';
+				$order = $post->menu_order;
+				$filter_inside_posts = apply_filters('sortable_post_inside_tax', array());
+				if( is_array( $filter_inside_posts ) ){
+				  foreach ( $filter_inside_posts as $key=>$combo ) {
+				    if($combo['post_type'] === $post->post_type && $combo['taxonomy'] === $wp_query->query_vars['taxonomy']){
+					$order = get_post_meta( $post->ID, '_sortable_posts_order_' . $post->post_type . '-' . $wp_query->query_vars['taxonomy'] . '-' . $wp_query->query_vars['term'], true );
+					break;
+				    }
+				  }
+				}
+				echo '<strong class="sortable-posts-order-position">' . $order . '</strong>';
 			}
 		}
 
@@ -255,26 +267,86 @@ if( ! class_exists( 'SortablePosts' ) ) {
 		 */
 		function order_by_sortable_posts( $query )
 		{
+			$post_type = get_post_type();
+			if(isset($query->query_vars['post_type'])) {
+			  $post_type = $query->query_vars['post_type'];
+			}
+			if( !is_admin() && (isset($query->query_vars['post_type']) && $query->query_vars['post_type'] === 'page') ) {
+			  $post_type = get_post_type();
+			}
+			if(empty($post_type)) {
+			  return;
+			}
+			$object = get_queried_object();
+			if(!empty($object)) {
+			  $taxonomy = $object->taxonomy;
+			  $taxonomy_term = $object->slug;
+			}
+			
 			// Check if post type is set and if its sortable
-			if( isset( $query->query_vars['post_type'] ) &&
-				in_array( $query->query_vars['post_type'], $this->sortable_types ) ) {
-				
-				// Override on admin
-				if( is_admin() ) {
-					$query->set( 'orderby', 'menu_order' );
-					$query->set( 'order', 'ASC' );
-				} else {
-					// User submitted orderby takes priority to allow for override in frontend
-					if( ! isset( $query->query_vars['orderby'] ) ) {
-						$query->set( 'orderby', 'menu_order' );
+			if( in_array( $post_type, $this->sortable_types ) ) {
+				$inside_tax = 0;
+				$filter_inside_posts = apply_filters('sortable_post_inside_tax', array());
+				if( is_array( $filter_inside_posts ) ){
+				  foreach ( $filter_inside_posts as $combo ) {
+				    if($combo['post_type'] === $post_type && $combo['taxonomy'] === $taxonomy){
+					$inside_tax = true;
+					$taxonomy = $combo['taxonomy'];
+					if(isset($query->query_vars[$combo['taxonomy']])){
+					  $taxonomy_term = $query->query_vars[$combo['taxonomy']];
 					}
-					
-					// User submitted order takes priority to allow for override in frontend
-					if( ! isset( $query->query_vars['order'] ) ) {
-						$query->set( 'order', 'ASC');
-					}
+					break;
+				    }
+				  }
 				}
-				
+				if ( !$inside_tax ) {
+				  // Override on admin
+				  if( is_admin() ) {
+					  $query->set( 'orderby', 'menu_order' );
+					  $query->set( 'order', 'ASC' );
+				  } else {
+					  // User submitted orderby takes priority to allow for override in frontend
+					  if( ! isset( $query->query_vars['orderby'] ) ) {
+						  $query->set( 'orderby', 'menu_order' );
+					  }
+
+					  // User submitted order takes priority to allow for override in frontend
+					  if( ! isset( $query->query_vars['order'] ) ) {
+						  $query->set( 'order', 'ASC');
+					  }
+				  }
+				} else {
+				  
+				  $query->set( 'meta_key', '_sortable_posts_order_' . $post_type . '-' . $taxonomy . '-' . $taxonomy_term );
+				  if( is_admin() ) {
+					  $query->set( 'orderby', 'meta_value_num' );
+					  $query->set( 'order', 'ASC' );
+				  } else {
+					  if (isset($query->query_vars['post_type']) && $query->query_vars['post_type'] === 'page' ) {
+						$query->query[ 'meta_key'] = '_sortable_posts_order_' . $post_type . '-' . $taxonomy . '-' . $taxonomy_term;
+						$query->query[ 'orderby'] = 'meta_value_num';
+						$query->query[ 'order' ] = 'ASC';
+						$query->query[ 'post_type' ] = $post_type;
+						$query->query_vars[ 'orderby'] = 'meta_value_num';
+						$query->query_vars[ 'order' ] = 'ASC';
+						$query->query_vars[ 'post_type' ] = $post_type;
+					  }
+					  if(is_archive() || is_tax()) {
+					    
+					  }
+					  // User submitted orderby takes priority to allow for override in frontend
+					  if( ! isset( $query->query_vars['orderby'] ) ) {
+						  $query->set( 'orderby', 'meta_value_num' );
+					  }
+
+					  // User submitted order takes priority to allow for override in frontend
+					  if( ! isset( $query->query_vars['order'] ) ) {
+						  $query->set( 'order', 'ASC');
+					  }
+				  }
+				  
+			  error_log(print_r($query, true));
+				}				
 			}
 		}
 

--- a/sortable-posts.php
+++ b/sortable-posts.php
@@ -292,6 +292,9 @@ if( ! class_exists( 'SortablePosts' ) ) {
 				  $taxonomy = $queried->taxonomy;
 				  $taxonomy_term = $queried->slug;
 				} elseif(isset($query->query['tax_query'])){
+                                  if ( empty( $query->query['tax_query'] ) ) {
+                                    return false;
+                                  }
 				  // This check if a custom WP_query
 				  $taxonomy = $query->query['tax_query'][0]['taxonomy'];
 				  $taxonomy_term = $query->query['tax_query'][0]['terms'];


### PR DESCRIPTION
I implemented a new feature that enable to order the posts when in the backend you are viewing the list of post with a specific taxonomy term.
In that way is possible to order them with a custom order that not use the menu_order to avoid conflicts.
The new feature create a new meta `'_sortable_posts_order_{taxonomy}_{term}` in that way is possible to order also the same post in different taxonomy or term.

To enable it there is a new filter.

``` php
add_filter( 'sortable_post_inside_tax', 'add_sortable_by_meta' );

function add_sortable_by_meta( $array ) {
    $array[] = array( 'post_type' => 'task', 'taxonomy' => 'task-area' );
    return $array;
}
```

In that way in the backend for `task-area` is possible to order the post type `task`.
In the archive of that child terms they are already ordered, on custom wp_query and obviously in the backend.
